### PR TITLE
feature - host labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options:
   --echo              Print the docker run command to the console, instead of
                       running it
   --sudo              Use sudo for docker run ...
+  --labels TEXT       Comma delimited list of k=v host labels
   --help              Show this message and exit.
 
 ```

--- a/rancher_agent_registration/cli.py
+++ b/rancher_agent_registration/cli.py
@@ -17,7 +17,9 @@ from time import sleep
               help="Print the docker run command to the console, instead of running it")
 @click.option('--sudo', default=True, is_flag=True,
               help="Use sudo for docker run ...")
-def main(url, key, secret, environment, echo, sudo):
+@click.option('--labels', default = None,
+              help="Comma delimited list of k=v host labels")
+def main(url, key, secret, environment, echo, sudo, labels):
     """Registers the current host with your Rancher server, creating the necessary registration keys."""
     # split url to protocol and host
     if "://" not in url:
@@ -74,6 +76,11 @@ def main(url, key, secret, environment, echo, sudo):
 
     if not command:
         bail("Cant register this host: Rancher didn't activate the new registration token.")
+
+    if labels:
+        labels = labels.replace(',', '&')
+        point = command.find('run')+len('run')
+        command = command[:point] + " -e CATTLE_HOST_LABELS='{0}'".format(labels) + command[point:]
 
     if echo:
         msg(command)


### PR DESCRIPTION
Provide the ability to add a comma-delimited list of host labels for the new rancher host.

Example:

```
$ rancher-agent-registration --url http://rancher:8080 --key <api-key> --secret <api-secret> --labels='foo=bar,hello=world' --echo

sudo docker run -e CATTLE_HOST_LABELS='foo=bar&hello=world' -d --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/rancher:/var/lib/rancher rancher/agent:v1.0.2 http://rancher:8080/v1/scripts/<registration_token>
```
